### PR TITLE
Handle empty results

### DIFF
--- a/lib/Media.js
+++ b/lib/Media.js
@@ -21,9 +21,9 @@
       return delete api.media.mixin;
     };
 
-    Media._result = function(data, field, evt, fn) {
+    Media._result = function(data, field, evt, defaultValue, fn) {
       var d;
-      d = Media.api.scrub(data.result[field]);
+      d = data.result[field] ? Media.api.scrub(data.result[field]) : defaultValue;
       pubsub.emit('api:' + evt, d);
       if (fn) {
         fn(d);
@@ -47,7 +47,7 @@
       };
       dfd = Media.api.send('VideoLibrary.GetTVShows', args);
       return dfd.then(function(data) {
-        return Media._result(data, 'tvshows', 'tvshow', fn);
+        return Media._result(data, 'tvshows', 'tvshow', [], fn);
       });
     };
 
@@ -66,7 +66,7 @@
       };
       dfd = Media.api.send('VideoLibrary.GetTVShowDetails', args);
       return dfd.then(function(data) {
-        return Media._result(data, 'tvshowdetails', 'tvshow', fn);
+        return Media._result(data, 'tvshowdetails', 'tvshow', null, fn);
       });
     };
 
@@ -98,7 +98,7 @@
       }
       dfd = Media.api.send('VideoLibrary.GetEpisodes', args);
       return dfd.then(function(data) {
-        return Media._result(data, 'episodes', 'episodes', fn);
+        return Media._result(data, 'episodes', 'episodes', [], fn);
       });
     };
 
@@ -117,7 +117,7 @@
       };
       dfd = Media.api.send('VideoLibrary.GetEpisodeDetails', args);
       return dfd.then(function(data) {
-        return Media._result(data, 'episodedetails', 'episode', fn);
+        return Media._result(data, 'episodedetails', 'episode', null, fn);
       });
     };
 
@@ -137,7 +137,7 @@
       };
       dfd = Media.api.send('VideoLibrary.GetMovies', args);
       return dfd.then(function(data) {
-        return Media._result(data, 'movies', 'movies', fn);
+        return Media._result(data, 'movies', 'movies', [], fn);
       });
     };
 
@@ -160,7 +160,7 @@
         properties: options.properties || ['title', 'year', 'plotoutline', 'plot', 'thumbnail']
       });
       return dfd.then(function(data) {
-        return Media._result(data, 'moviedetails', 'movie', fn);
+        return Media._result(data, 'moviedetails', 'movie', null, fn);
       });
     };
 

--- a/src/Media.coffee
+++ b/src/Media.coffee
@@ -9,8 +9,8 @@ class Media
     api.media[name] = method for name, method of @
     delete api.media.mixin
 
-  @_result: (data, field, evt, fn) =>
-    d = @api.scrub data.result[field]
+  @_result: (data, field, evt, defaultValue, fn) =>
+    d = if data.result[field] then @api.scrub data.result[field] else defaultValue
     pubsub.emit 'api:' + evt, d
     fn d if fn
     d
@@ -23,7 +23,7 @@ class Media
       limits:     options.limits     || {}
     dfd = @api.send 'VideoLibrary.GetTVShows', args
     dfd.then (data) =>
-      @_result data, 'tvshows', 'tvshow', fn
+      @_result data, 'tvshows', 'tvshow', [], fn
 
   @tvshow: (id, options = {}, fn = null) =>
     debug 'tvshow', id, options
@@ -32,7 +32,7 @@ class Media
       properties: options.properties || []
     dfd = @api.send 'VideoLibrary.GetTVShowDetails', args
     dfd.then (data) =>
-      @_result data, 'tvshowdetails', 'tvshow', fn
+      @_result data, 'tvshowdetails', 'tvshow', null, fn
 
   @episodes: (tvshowid = -1, season = -1, options = {}, fn = null) =>
     debug 'episodes', options
@@ -44,7 +44,7 @@ class Media
     args.season = season if season >= 0
     dfd = @api.send 'VideoLibrary.GetEpisodes', args
     dfd.then (data) =>
-      @_result data, 'episodes', 'episodes', fn
+      @_result data, 'episodes', 'episodes', [], fn
 
   @episode: (id, options = {}, fn = null) =>
     debug 'episode', id, options
@@ -60,7 +60,7 @@ class Media
       ]
     dfd = @api.send 'VideoLibrary.GetEpisodeDetails', args
     dfd.then (data) =>
-      @_result data, 'episodedetails', 'episode', fn
+      @_result data, 'episodedetails', 'episode', null, fn
 
   @movies: (options = {}, fn = null) =>
     debug 'movies', options
@@ -70,7 +70,7 @@ class Media
       limits:     options.limits     || {}
     dfd = @api.send 'VideoLibrary.GetMovies', args
     dfd.then (data) =>
-      @_result data, 'movies', 'movies', fn
+      @_result data, 'movies', 'movies', [], fn
 
   @movie: (id, options = {}, fn = null) =>
     debug 'movie', id, options
@@ -89,6 +89,6 @@ class Media
         'thumbnail'
       ]
     dfd.then (data) =>
-      @_result data, 'moviedetails', 'movie', fn
+      @_result data, 'moviedetails', 'movie', null, fn
 
 module.exports = Media


### PR DESCRIPTION
If I run [my script](https://github.com/timdp/kodi-missing-episodes) for finding missing episodes against a nightly build of Kodi (currently on LibreELEC devel-20160428210317-#0428-g8b0c952), it chokes on an endpoint returning an empty result set. This gets sent back:

``` js
{ id: '__id4',
  jsonrpc: '2.0',
  result: { limits: { end: 0, start: 0, total: 0 } } }
```

The underlying reason is that `Media::_result` expects there to be an `episodes` key pointing to an array value, which doesn't seem to be the case anymore if there are no results. `Media::_result` delegates to `XbmcApi::scrub`, which tries to access the `thumbnail` property of the `episodes` value, which is undefined, and it crashes.

My proposed fix is to check if the property is set and if not, fall back to a default value. Presumably, that default value is an empty array for endpoints with a plural name. For singular names, I just used `null`, mostly assuming it'll never actually hit that code.

Alternatively, we could make `scrub` check if `data` exists, but then, the caller will still return `undefined` rather than an array, which will probably still crash existing code.

It could be that I'm doing something wrong in my code as well, but at any rate, I think it's safer to always respond with an array.
